### PR TITLE
fix: sort cached lobbies so refresh stays ordered by created

### DIFF
--- a/src/liveLobbies.ts
+++ b/src/liveLobbies.ts
@@ -472,7 +472,15 @@ const updateLobbies = async () => {
     "seconds.",
   );
 
-  cachedLobbies = [...lobbyCache.values()];
+  cachedLobbies = [...lobbyCache.values()].sort((a, b) =>
+    (a.created && b.created)
+      ? b.created - a.created
+      : a.created
+      ? 1
+      : b.created
+      ? -1
+      : 0
+  );
   notifyHealthy();
 };
 


### PR DESCRIPTION
The /lobbies JSON endpoint paginated cachedLobbies in Map insertion
order, so the status page's auto-refresh fetched the first N lobbies
in cache order and only sorted that page client-side. Sort once when
populating the cache so all consumers (initial render, paginated API,
and home-page filter test) see the same created-desc order.