### PR TITLE
feat: filtered total + fix status page limit

### DIFF
--- a/src/api/routes/getLobbies.ts
+++ b/src/api/routes/getLobbies.ts
@@ -50,24 +50,22 @@ export const getLobbies: Handler = (ctx) => {
     0,
   );
 
-  const need = offset + limit + 1;
-  let collected: typeof allLobbies;
+  let matched: typeof allLobbies;
+  let total: number;
   if (!filters.hasFilters) {
-    collected = allLobbies.slice(0, need);
+    matched = allLobbies;
+    total = allLobbies.length;
   } else {
-    collected = [];
-    for (const l of allLobbies) {
-      if (matches(l, filters)) {
-        collected.push(l);
-        if (collected.length >= need) break;
-      }
-    }
+    matched = allLobbies.filter((l) => matches(l, filters));
+    total = matched.length;
   }
 
+  const page = matched.slice(offset, offset + limit);
   const payload = {
-    lobbies: collected.slice(offset, offset + limit),
-    total: allLobbies.length,
-    hasMore: collected.length > offset + limit,
+    lobbies: page,
+    total,
+    totalUnfiltered: allLobbies.length,
+    hasMore: offset + page.length < total,
     lastUpdate: stats.lastDataUpdate,
     liveness: getSourceLiveness(),
   };

--- a/src/api/routes/getStatus.ts
+++ b/src/api/routes/getStatus.ts
@@ -263,6 +263,7 @@ export const getStatus: Handler = () => {
 
   let lobbies = ${JSON.stringify(lobbies)};
   let total = ${allLobbies.length};
+  let totalUnfiltered = ${allLobbies.length};
   let hasMore = ${allLobbies.length > 100};
   let lastUpdate = ${stats.lastDataUpdate ?? "undefined"};
   let liveness = ${JSON.stringify(liveness)};
@@ -291,12 +292,13 @@ export const getStatus: Handler = () => {
       lobbies = lobbies.concat(data.lobbies.sort(lobbySort));
     }
     total = data.total;
+    totalUnfiltered = data.totalUnfiltered;
     hasMore = data.hasMore;
     lastUpdate = data.lastUpdate;
     liveness = data.liveness;
   };
 
-  const refresh = () => fetchPage(0, lobbies.length || PAGE).then(render);
+  const refresh = () => fetchPage(0, Math.max(lobbies.length, PAGE)).then(render);
 
   const fetchMore = async () => {
     if (fetching || !hasMore) return;
@@ -317,7 +319,7 @@ export const getStatus: Handler = () => {
 
   const render = () => {
     document.getElementById("lastUpdate").textContent = formatTime(Math.round(lastUpdate/1000), "long");
-    document.getElementById("lobbyCount").textContent = total;
+    document.getElementById("lobbyCount").textContent = total === totalUnfiltered ? total : (total + " of " + totalUnfiltered);
     const wc3StatsStatus = liveness.wc3statsUp ? "up" : "down";
     const wc3MapsStatus = liveness.wc3mapsUp ? "up" : "down";
     const wc3StatsEl = document.getElementById("wc3statsStatus");


### PR DESCRIPTION
## Summary
- `/lobbies`: `total` now reflects the filtered match count; added `totalUnfiltered` for the overall cache size. `hasMore` derives from the filtered total.
- Status page: show `X of Y` when filters are active; fix `refresh` sending `limit=lobbies.length` once filters dropped the visible count below the page size (now `Math.max(lobbies.length, PAGE)`).

## Test plan
- [ ] `GET /lobbies` with no filters: `total === totalUnfiltered`, response shape unchanged otherwise
- [ ] `GET /lobbies?map=foo`: `total` is the filtered match count, `totalUnfiltered` is the full cache size, `hasMore` paginates within the filtered set
- [ ] Status page with no filters: header shows just the number (e.g. `Lobbies: 1247`)
- [ ] Status page with a filter that returns <100 results: header shows `X of Y`, and the periodic refresh request keeps `limit=100` instead of shrinking to the filtered count

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf1C8bukWoft9Lp5FF9Bjm)_