### PR TITLE
Add usage metrics tracking and display on status page

### DIFF
--- a/src/api/routes/getLobbies.ts
+++ b/src/api/routes/getLobbies.ts
@@ -1,5 +1,6 @@
 import { getCachedLobbies, process, stats } from "../../liveLobbies.ts";
 import { getSourceLiveness, Lobby } from "../../sources/lobbies.ts";
+import { getMetricsSummary } from "../../sources/metrics.ts";
 import { Handler } from "../types.ts";
 import { ansiToHTML } from "../util/ansiToHTML.ts";
 
@@ -38,7 +39,7 @@ const matches = (
   (!filters.alive || !lobby.deadAt) &&
   (!filters.tracked || !!lobby.messages.length);
 
-export const getLobbies: Handler = (ctx) => {
+export const getLobbies: Handler = async (ctx) => {
   const allLobbies = getCachedLobbies();
   const filters = parseFilters(ctx.url.searchParams);
   const limit = Math.min(
@@ -68,6 +69,7 @@ export const getLobbies: Handler = (ctx) => {
     hasMore: offset + page.length < total,
     lastUpdate: stats.lastDataUpdate,
     liveness: getSourceLiveness(),
+    metrics: await getMetricsSummary(),
   };
 
   if (ctx.req.headers.get("accept")?.includes("application/json")) {
@@ -106,15 +108,15 @@ export const getLobbies: Handler = (ctx) => {
 </head>
 <body>
   ${`<pre>${
-        ansiToHTML(
-          Deno.inspect(payload, {
-            colors: true,
-            depth: Infinity,
-            compact: true,
-            iterableLimit: Infinity,
-          }),
-        )
-      }</pre>`}
+      ansiToHTML(
+        Deno.inspect(payload, {
+          colors: true,
+          depth: Infinity,
+          compact: true,
+          iterableLimit: Infinity,
+        }),
+      )
+    }</pre>`}
 <body>`,
     { headers: { "content-type": "text/html; charset=utf-8" } },
   );

--- a/src/api/routes/getStatus.ts
+++ b/src/api/routes/getStatus.ts
@@ -1,5 +1,6 @@
 import { getCachedLobbies, stats } from "../../liveLobbies.ts";
 import { getSourceLiveness, Lobby } from "../../sources/lobbies.ts";
+import { getMetricsSummary, MetricsWindow } from "../../sources/metrics.ts";
 import { Handler } from "../types.ts";
 
 export const formatTime = (
@@ -38,8 +39,14 @@ const lobbySort = (a: Lobby, b: Lobby) =>
     ? -1
     : 0;
 
-export const getStatus: Handler = () => {
+export const metricsHTML = (metrics: MetricsWindow[]) =>
+  metrics.map((m) =>
+    `<div class="metric"><span class="metric-label">${m.label}</span><span class="metric-val">${m.lobbies.toLocaleString()} lobbies</span><span class="metric-sub">${m.servers.toLocaleString()} servers &middot; ${m.updates.toLocaleString()} updates</span></div>`
+  ).join("");
+
+export const getStatus: Handler = async () => {
   const liveness = getSourceLiveness();
+  const metrics = await getMetricsSummary();
   const allLobbies = [...getCachedLobbies()].sort(lobbySort);
   const lobbies = allLobbies.slice(0, 100);
 
@@ -70,6 +77,24 @@ export const getStatus: Handler = () => {
   .meta span { white-space: nowrap }
   .meta .up { color: #4ec97a }
   .meta .down { color: #e05252 }
+  .metrics { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 24px }
+  .metric {
+    flex: 1 1 auto; min-width: 104px;
+    background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 8px;
+    padding: 10px 12px;
+  }
+  .metric-label {
+    display: block; font-size: 11px; text-transform: uppercase;
+    letter-spacing: 0.5px; color: #888; margin-bottom: 5px;
+  }
+  .metric-val {
+    display: block; color: #fff; font-size: 16px; font-weight: 500;
+    font-variant-numeric: tabular-nums;
+  }
+  .metric-sub {
+    display: block; font-size: 11px; color: #666; margin-top: 2px;
+    font-variant-numeric: tabular-nums;
+  }
   table { width: 100%; border-collapse: collapse; table-layout: fixed }
   thead { position: sticky; top: 0; z-index: 1; background: #111 }
   th {
@@ -260,8 +285,10 @@ export const getStatus: Handler = () => {
   import morphdom from "https://esm.sh/morphdom";
   const lobbySort = ${lobbySort.toString()};
   const formatTime = ${formatTime.toString()};
+  const metricsHTML = ${metricsHTML.toString()};
 
   let lobbies = ${JSON.stringify(lobbies)};
+  let metrics = ${JSON.stringify(metrics)};
   let total = ${allLobbies.length};
   let totalUnfiltered = ${allLobbies.length};
   let hasMore = ${allLobbies.length > 100};
@@ -296,6 +323,7 @@ export const getStatus: Handler = () => {
     hasMore = data.hasMore;
     lastUpdate = data.lastUpdate;
     liveness = data.liveness;
+    metrics = data.metrics;
   };
 
   const refresh = () => fetchPage(0, Math.max(lobbies.length, PAGE)).then(render);
@@ -329,6 +357,7 @@ export const getStatus: Handler = () => {
     wc3MapsEl.textContent = wc3MapsStatus;
     wc3MapsEl.className = wc3MapsStatus;
     document.getElementById("wc3mapsBadge").style.display = liveness.wc3mapsChecked ? "" : "none";
+    if (metrics) document.getElementById("metrics").innerHTML = metricsHTML(metrics);
 
     morphdom(document.querySelector("tbody"), \`<tbody>\${lobbies.map(l => \`<tr id="\${l.id}">
       <td class="col-map" title="\${l.map}">\${l.map}</td>
@@ -380,6 +409,7 @@ export const getStatus: Handler = () => {
     }</span></span>
     <span>Lobbies: <span id="lobbyCount">${allLobbies.length}</span></span>
   </div>
+  <div class="metrics" id="metrics">${metricsHTML(metrics)}</div>
   <table>
     <thead>
       <tr class="col-headers">

--- a/src/liveLobbies.ts
+++ b/src/liveLobbies.ts
@@ -361,7 +361,11 @@ const updateLobbies = async () => {
   let pendingReplay = 0;
   let cleared = 0;
   let linked = 0;
-  const newServers = new Set<string>();
+  // Metrics only count work we actually emit to Discord: lobbies we echoed to at
+  // least one channel and updates that edited at least one live message.
+  let echoedLobbies = 0;
+  let echoedUpdates = 0;
+  const echoedServers = new Set<string>();
 
   for (const newLobby of newLobbies) {
     let oldLobby = oldLobbies.find((l) => l.id === newLobby.id);
@@ -377,14 +381,20 @@ const updateLobbies = async () => {
     if (!oldLobby) {
       newLobby.messages = await onNewLobby(newLobby, alerts, dataSource);
       news++;
-      newServers.add(newLobby.server);
+      if (newLobby.messages.length) {
+        echoedLobbies++;
+        echoedServers.add(newLobby.server);
+      }
       await setLobby(newLobby);
     } else {
       newLobby.messages = oldLobby.messages;
       if ((newLobby.slotsTaken !== oldLobby.slotsTaken) || oldLobby.deadAt) {
         await onUpdateLobby(newLobby, dataSource, alerts);
         if (oldLobby.deadAt) found++;
-        else updates++;
+        else {
+          updates++;
+          if (newLobby.messages.length) echoedUpdates++;
+        }
       } else stable++;
       await setLobby(newLobby);
     }
@@ -482,9 +492,9 @@ const updateLobbies = async () => {
   );
 
   await recordMetrics({
-    lobbies: news,
-    updates,
-    servers: [...newServers],
+    lobbies: echoedLobbies,
+    updates: echoedUpdates,
+    servers: [...echoedServers],
   });
 
   cachedLobbies = [...lobbyCache.values()].sort((a, b) =>

--- a/src/liveLobbies.ts
+++ b/src/liveLobbies.ts
@@ -11,6 +11,7 @@ import { DiscordAPIError } from "npm:@discordjs/rest@2.3.0";
 import { AllowedMentionsTypes, APIEmbed } from "npm:discord-api-types/v10";
 import { getReplayMap, getReplays } from "./sources/replays.ts";
 import { notifyHealthy, notifyReady } from "./sources/watchdog.ts";
+import { recordMetrics } from "./sources/metrics.ts";
 import { renderMessage } from "./template.ts";
 
 export const stats = { lastDataUpdate: 0 };
@@ -360,6 +361,7 @@ const updateLobbies = async () => {
   let pendingReplay = 0;
   let cleared = 0;
   let linked = 0;
+  const newServers = new Set<string>();
 
   for (const newLobby of newLobbies) {
     let oldLobby = oldLobbies.find((l) => l.id === newLobby.id);
@@ -375,6 +377,7 @@ const updateLobbies = async () => {
     if (!oldLobby) {
       newLobby.messages = await onNewLobby(newLobby, alerts, dataSource);
       news++;
+      newServers.add(newLobby.server);
       await setLobby(newLobby);
     } else {
       newLobby.messages = oldLobby.messages;
@@ -477,6 +480,12 @@ const updateLobbies = async () => {
     Math.round((Date.now() - now) / 10) / 100,
     "seconds.",
   );
+
+  await recordMetrics({
+    lobbies: news,
+    updates,
+    servers: [...newServers],
+  });
 
   cachedLobbies = [...lobbyCache.values()].sort((a, b) =>
     (a.created && b.created)

--- a/src/sources/kv.ts
+++ b/src/sources/kv.ts
@@ -3,7 +3,7 @@ import { z } from "npm:zod";
 import { zLobby } from "./lobbies.ts";
 import { getLastReplayId } from "./replays.ts";
 
-const kv = await Deno.openKv();
+export const kv = await Deno.openKv();
 
 export const zAlert = z.object({
   channelId: z.string(),

--- a/src/sources/metrics.ts
+++ b/src/sources/metrics.ts
@@ -1,0 +1,165 @@
+import { kv } from "./kv.ts";
+
+// Cheap usage metrics: how many lobbies were posted, how many updates we sent,
+// and across how many distinct realms — bucketed over a handful of rolling time
+// windows for the status page.
+//
+// We keep two resolutions of time buckets plus a single all-time aggregate:
+//   - hourly buckets cover the <= 1 day windows
+//   - daily buckets cover the > 1 day windows
+// WC3 has only a handful of realms, so the per-bucket server set stays tiny and
+// unioning them to count distinct realms is essentially free.
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+// Retain a little past each window so the largest window always has full data.
+const HOURS_KEPT = 48; // covers the 24h window
+const DAYS_KEPT = 400; // covers the 365d window
+
+type Bucket = { lobbies: number; updates: number; servers: string[] };
+
+const empty = (): Bucket => ({ lobbies: 0, updates: 0, servers: [] });
+
+const hourKey = (index: number) => ["metrics", "hour", index];
+const dayKey = (index: number) => ["metrics", "day", index];
+const allKey = ["metrics", "all"];
+
+const merge = (base: Bucket, add: Bucket): Bucket => ({
+  lobbies: base.lobbies + add.lobbies,
+  updates: base.updates + add.updates,
+  servers: [...new Set([...base.servers, ...add.servers])],
+});
+
+const pruneOld = async (hour: number, day: number) => {
+  try {
+    const stale: Deno.KvKey[] = [];
+    for await (
+      const e of kv.list({ prefix: ["metrics", "hour"] }, { batchSize: 500 })
+    ) {
+      if ((e.key.at(-1) as number) < hour - HOURS_KEPT) stale.push(e.key);
+    }
+    for await (
+      const e of kv.list({ prefix: ["metrics", "day"] }, { batchSize: 500 })
+    ) {
+      if ((e.key.at(-1) as number) < day - DAYS_KEPT) stale.push(e.key);
+    }
+    await Promise.all(stale.map((k) => kv.delete(k)));
+  } catch (err) {
+    console.error(new Date(), "Failed to prune metrics buckets", err);
+  }
+};
+
+/**
+ * Record a cycle's worth of activity. `servers` should be the realms of the
+ * lobbies counted in `lobbies`. No-ops when there's nothing to record.
+ */
+export const recordMetrics = async (
+  add: { lobbies: number; updates: number; servers: string[] },
+) => {
+  if (!add.lobbies && !add.updates) return;
+  try {
+    const now = Date.now();
+    const hour = Math.floor(now / HOUR);
+    const day = Math.floor(now / DAY);
+
+    const [hourB, dayB, allB] = await Promise.all([
+      kv.get<Bucket>(hourKey(hour)),
+      kv.get<Bucket>(dayKey(day)),
+      kv.get<Bucket>(allKey),
+    ]);
+
+    const sample: Bucket = {
+      lobbies: add.lobbies,
+      updates: add.updates,
+      servers: [...new Set(add.servers)],
+    };
+
+    await Promise.all([
+      kv.set(hourKey(hour), merge(hourB.value ?? empty(), sample)),
+      kv.set(dayKey(day), merge(dayB.value ?? empty(), sample)),
+      kv.set(allKey, merge(allB.value ?? empty(), sample)),
+    ]);
+
+    // A freshly created hour bucket means the clock rolled over — a good, cheap
+    // moment (once an hour) to sweep away expired buckets.
+    if (!hourB.value) await pruneOld(hour, day);
+  } catch (err) {
+    console.error(new Date(), "Failed to record metrics", err);
+  }
+};
+
+export type MetricsWindow = {
+  label: string;
+  lobbies: number;
+  updates: number;
+  servers: number;
+};
+
+const windows: { label: string; ms: number; daily: boolean }[] = [
+  { label: "1h", ms: HOUR, daily: false },
+  { label: "24h", ms: DAY, daily: false },
+  { label: "7d", ms: 7 * DAY, daily: true },
+  { label: "30d", ms: 30 * DAY, daily: true },
+  { label: "90d", ms: 90 * DAY, daily: true },
+  { label: "1y", ms: 365 * DAY, daily: true },
+];
+
+const readBuckets = async (
+  prefix: Deno.KvKey,
+): Promise<Map<number, Bucket>> => {
+  const map = new Map<number, Bucket>();
+  for await (const e of kv.list<Bucket>({ prefix }, { batchSize: 500 })) {
+    map.set(e.key.at(-1) as number, e.value);
+  }
+  return map;
+};
+
+let cache: { at: number; summary: MetricsWindow[] } | undefined;
+const CACHE_MS = 60_000;
+
+/**
+ * Summarize activity across each rolling window. Counts are over-approximate at
+ * the bucket boundary (the oldest bucket touched is included whole), which is
+ * plenty precise for a usage dashboard. Cached for a minute.
+ */
+export const getMetricsSummary = async (): Promise<MetricsWindow[]> => {
+  if (cache && Date.now() - cache.at < CACHE_MS) return cache.summary;
+
+  const now = Date.now();
+  const [hourly, daily, all] = await Promise.all([
+    readBuckets(["metrics", "hour"]),
+    readBuckets(["metrics", "day"]),
+    kv.get<Bucket>(allKey),
+  ]);
+
+  const summary: MetricsWindow[] = windows.map(
+    ({ label, ms, daily: byDay }) => {
+      const size = byDay ? DAY : HOUR;
+      const cutoff = Math.floor((now - ms) / size);
+      const source = byDay ? daily : hourly;
+
+      let lobbies = 0;
+      let updates = 0;
+      const servers = new Set<string>();
+      for (const [index, b] of source) {
+        if (index < cutoff) continue;
+        lobbies += b.lobbies;
+        updates += b.updates;
+        for (const s of b.servers) servers.add(s);
+      }
+      return { label, lobbies, updates, servers: servers.size };
+    },
+  );
+
+  const allB = all.value ?? empty();
+  summary.push({
+    label: "All",
+    lobbies: allB.lobbies,
+    updates: allB.updates,
+    servers: allB.servers.length,
+  });
+
+  cache = { at: now, summary };
+  return summary;
+};


### PR DESCRIPTION
## Summary
This PR adds comprehensive usage metrics tracking to monitor lobby activity and realm usage across multiple time windows. Metrics are recorded on each update cycle and displayed on the status page dashboard.

## Key Changes
- **New metrics module** (`src/sources/metrics.ts`): Implements metrics collection with rolling time windows (hourly and daily buckets) covering 1h, 24h, 7d, 30d, 90d, 1y, and all-time periods. Includes automatic pruning of stale buckets and 1-minute caching of summary data.
- **Metrics recording**: Integrated into the lobby update cycle (`src/liveLobbies.ts`) to track newly posted lobbies, update counts, and distinct realms per cycle.
- **Status page display**: Added metrics visualization to the status dashboard (`src/api/routes/getStatus.ts`) with styled metric cards showing lobby counts, server counts, and update counts for each time window.
- **API response enhancement**: Updated `getLobbies` endpoint to include metrics summary in responses for both JSON and HTML formats.
- **KV store export**: Made the `kv` instance exportable from `src/sources/kv.ts` to support the new metrics module.

## Implementation Details
- Metrics use Deno KV for persistent storage with keys organized by time bucket (hour/day indices)
- Distinct realm counts are maintained using Sets and merged across buckets
- Automatic cleanup triggered hourly when a new hour bucket is created
- Frontend updates metrics display via morphdom when data refreshes
- Metrics are over-approximate at bucket boundaries (includes full oldest bucket) but sufficiently precise for a usage dashboard

https://claude.ai/code/session_01Q5ajSvRJDP1UUu7EHybdzL