### PR TITLE
chore: satisfy deno lint by moving deps to an import map

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,17 @@
 {
   "tasks": {
     "dev": "deno run --watch -A --unstable-kv --unstable-cron src/index.ts"
+  },
+  "imports": {
+    "@discordjs/core": "npm:@discordjs/core@1.2.0",
+    "@discordjs/rest": "npm:@discordjs/rest@2.3.0",
+    "@olli/kvdex": "jsr:@olli/kvdex@^3.1.3",
+    "@std/assert": "jsr:@std/assert@^1.0.8",
+    "@std/fmt/": "jsr:/@std/fmt@^1.0.3/",
+    "@std/http": "jsr:@std/http@^1.0.12",
+    "@std/http/": "jsr:/@std/http@^1.0.12/",
+    "@std/path/": "jsr:/@std/path@^1.0.8/",
+    "discord-api-types/": "npm:/discord-api-types@0.37.83/",
+    "zod": "npm:zod@3.23.8"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -2,7 +2,9 @@
   "version": "5",
   "specifiers": {
     "jsr:@olli/kvdex@*": "3.1.3",
+    "jsr:@olli/kvdex@^3.1.3": "3.1.3",
     "jsr:@std/assert@*": "1.0.14",
+    "jsr:@std/assert@^1.0.8": "1.0.14",
     "jsr:@std/bytes@^1.0.4": "1.0.5",
     "jsr:@std/cli@^1.0.8": "1.0.12",
     "jsr:@std/collections@^1.0.9": "1.0.10",
@@ -11,6 +13,7 @@
     "jsr:@std/fmt@^1.0.3": "1.0.3",
     "jsr:@std/html@^1.0.3": "1.0.3",
     "jsr:@std/http@*": "1.0.12",
+    "jsr:@std/http@^1.0.12": "1.0.12",
     "jsr:@std/internal@^1.0.10": "1.0.10",
     "jsr:@std/media-types@^1.1.0": "1.1.0",
     "jsr:@std/net@^1.0.4": "1.0.4",
@@ -19,10 +22,13 @@
     "jsr:@std/streams@^1.0.8": "1.0.8",
     "jsr:@std/ulid@1": "1.0.0",
     "npm:@discordjs/core@*": "1.2.0",
+    "npm:@discordjs/core@1.2.0": "1.2.0",
     "npm:@discordjs/rest@*": "2.3.0",
     "npm:@discordjs/rest@2.3.0": "2.3.0",
     "npm:discord-api-types@*": "0.37.83",
-    "npm:zod@*": "3.23.8"
+    "npm:discord-api-types@0.37.83": "0.37.83",
+    "npm:zod@*": "3.23.8",
+    "npm:zod@3.23.8": "3.23.8"
   },
   "jsr": {
     "@olli/kvdex@3.1.3": {
@@ -172,14 +178,23 @@
       "integrity": "sha512-Q2rtqmZWrbP8nePMq7mOJIN98M0fYvSgV89vwl/BQRT4mDOeY2GXZngfGpcBBhtky3woM7G24wZV3Q304Bv6cw=="
     },
     "ws@8.18.0": {
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "optionalPeers": [
-        "bufferutil@^4.0.1",
-        "utf-8-validate@>=5.0.2"
-      ]
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="
     },
     "zod@3.23.8": {
       "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="
     }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@olli/kvdex@^3.1.3",
+      "jsr:@std/assert@^1.0.8",
+      "jsr:@std/fmt@^1.0.3",
+      "jsr:@std/http@^1.0.12",
+      "jsr:@std/path@^1.0.8",
+      "npm:@discordjs/core@1.2.0",
+      "npm:@discordjs/rest@2.3.0",
+      "npm:discord-api-types@0.37.83",
+      "npm:zod@3.23.8"
+    ]
   }
 }

--- a/src/api/routes/deleteAlert.ts
+++ b/src/api/routes/deleteAlert.ts
@@ -1,4 +1,4 @@
-import { z } from "npm:zod";
+import { z } from "zod";
 import { Handler } from "../types.ts";
 import { db } from "../../sources/kv.ts";
 import { APIError } from "../ErrorCode.ts";

--- a/src/api/routes/getAlert.ts
+++ b/src/api/routes/getAlert.ts
@@ -1,4 +1,4 @@
-import { z } from "npm:zod";
+import { z } from "zod";
 import { Handler } from "../types.ts";
 import { db } from "../../sources/kv.ts";
 import { APIError } from "../ErrorCode.ts";

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1,10 +1,10 @@
-import { blue, brightRed, green, red, yellow } from "jsr:@std/fmt/colors";
-import { STATUS_CODE } from "jsr:@std/http/status";
-import { format } from "jsr:@std/fmt/bytes";
-import { serveFile } from "jsr:@std/http";
-import { join } from "jsr:@std/path/join";
+import { blue, brightRed, green, red, yellow } from "@std/fmt/colors";
+import { STATUS_CODE } from "@std/http/status";
+import { format } from "@std/fmt/bytes";
+import { serveFile } from "@std/http";
+import { join } from "@std/path/join";
 import { APIError } from "./ErrorCode.ts";
-import { ZodError } from "npm:zod";
+import { ZodError } from "zod";
 import { routes } from "./routes.ts";
 import { SerializableResponse } from "./types.ts";
 

--- a/src/liveLobbies.ts
+++ b/src/liveLobbies.ts
@@ -7,8 +7,8 @@ import {
 } from "./sources/lobbies.ts";
 import { Alert, db, meta, Rule } from "./sources/kv.ts";
 import { discord, messageAdminAndWarn } from "./sources/discord.ts";
-import { DiscordAPIError } from "npm:@discordjs/rest@2.3.0";
-import { AllowedMentionsTypes, APIEmbed } from "npm:discord-api-types/v10";
+import { DiscordAPIError } from "@discordjs/rest";
+import { AllowedMentionsTypes, APIEmbed } from "discord-api-types/v10";
 import { getReplayMap, getReplays } from "./sources/replays.ts";
 import { notifyHealthy, notifyReady } from "./sources/watchdog.ts";
 import { recordMetrics } from "./sources/metrics.ts";

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,4 @@
-import { gray, red, yellow } from "jsr:@std/fmt/colors";
+import { gray, red, yellow } from "@std/fmt/colors";
 import { ansiToHTML } from "./api/util/ansiToHTML.ts";
 
 class MemoryBuffer {

--- a/src/sources/discord.ts
+++ b/src/sources/discord.ts
@@ -1,11 +1,11 @@
-import { REST } from "npm:@discordjs/rest";
-import { API } from "npm:@discordjs/core";
+import { REST } from "@discordjs/rest";
+import { API } from "@discordjs/core";
 import {
   APIChannel,
   APIMessage,
   ChannelType,
   RESTPostAPIChannelMessageJSONBody,
-} from "npm:discord-api-types/v10";
+} from "discord-api-types/v10";
 
 const rest = new REST({ version: "10" })
   .setToken(Deno.env.get("DISCORD_TOKEN")!);

--- a/src/sources/kv.ts
+++ b/src/sources/kv.ts
@@ -1,5 +1,5 @@
-import { collection, kvdex } from "jsr:@olli/kvdex";
-import { z } from "npm:zod";
+import { collection, kvdex } from "@olli/kvdex";
+import { z } from "zod";
 import { zLobby } from "./lobbies.ts";
 import { getLastReplayId } from "./replays.ts";
 

--- a/src/sources/lobbies.ts
+++ b/src/sources/lobbies.ts
@@ -1,4 +1,4 @@
-import { z } from "npm:zod";
+import { z } from "zod";
 import { discord, messageAdmin, messageAnders } from "./discord.ts";
 
 export const zLobby = z.object({

--- a/src/sources/replays.ts
+++ b/src/sources/replays.ts
@@ -1,4 +1,4 @@
-import { z } from "npm:zod";
+import { z } from "zod";
 import { zodFetch } from "./util.ts";
 import { meta } from "./kv.ts";
 

--- a/src/sources/util.ts
+++ b/src/sources/util.ts
@@ -1,4 +1,4 @@
-import { ZodType } from "npm:zod";
+import { ZodType } from "zod";
 
 export const zodFetch = async <T>(
   input: Parameters<typeof fetch>[0],

--- a/src/template.test.ts
+++ b/src/template.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert";
+import { assertEquals } from "@std/assert";
 import { renderMessage } from "./template.ts";
 
 const lobby = {


### PR DESCRIPTION
Clears the repo-wide `deno lint` errors (39 problems across 28 files, all `no-import-prefix` / `no-unversioned-import`).

## Changes
- Add an `imports` map to `deno.json` pinning every dependency.
- Switch all source imports from inline `npm:`/`jsr:` specifiers to bare names.
- Re-resolve `deno.lock` for the new specifiers.

The client-side `morphdom` URL in the status-page template is left as-is, since it's browser code rather than a Deno import (and lint doesn't flag it).

## Notes
The diff is import-only — the newer Deno's `deno fmt` wanted to reformat a few unrelated files (quote-style/line-reflow churn); that was reverted to keep this focused on the lint pass.

## Verification
- `deno lint` → 0 problems (was 39)
- `deno check` → passes
- `deno test` → 29 passed, 0 failed

https://claude.ai/code/session_01Q5ajSvRJDP1UUu7EHybdzL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5ajSvRJDP1UUu7EHybdzL)_