### PR TITLE
fix: count distinct Discord servers, not WC3 realms, in status metrics

### DIFF
--- a/src/liveLobbies.ts
+++ b/src/liveLobbies.ts
@@ -363,6 +363,7 @@ const updateLobbies = async () => {
   let linked = 0;
   // Metrics only count work we actually emit to Discord: lobbies we echoed to at
   // least one channel and updates that edited at least one live message.
+  // echoedServers tracks the distinct Discord servers (guilds) we posted to.
   let echoedLobbies = 0;
   let echoedUpdates = 0;
   const echoedServers = new Set<string>();
@@ -383,7 +384,14 @@ const updateLobbies = async () => {
       news++;
       if (newLobby.messages.length) {
         echoedLobbies++;
-        echoedServers.add(newLobby.server);
+        for (const { channel } of newLobby.messages) {
+          const meta = alerts.find((a) => a.channelId === channel)?.meta;
+          // Count distinct guilds we posted to; DMs have no guild, so fall back
+          // to the channel as the destination key.
+          echoedServers.add(
+            meta?.type === "guildChannel" ? meta.guildId : channel,
+          );
+        }
       }
       await setLobby(newLobby);
     } else {

--- a/src/sources/metrics.ts
+++ b/src/sources/metrics.ts
@@ -1,14 +1,14 @@
 import { kv } from "./kv.ts";
 
 // Cheap usage metrics: how many lobbies were posted, how many updates we sent,
-// and across how many distinct realms — bucketed over a handful of rolling time
-// windows for the status page.
+// and across how many distinct Discord servers — bucketed over a handful of
+// rolling time windows for the status page.
 //
 // We keep two resolutions of time buckets plus a single all-time aggregate:
 //   - hourly buckets cover the <= 1 day windows
 //   - daily buckets cover the > 1 day windows
-// WC3 has only a handful of realms, so the per-bucket server set stays tiny and
-// unioning them to count distinct realms is essentially free.
+// The bot serves a bounded number of guilds, so the per-bucket server set stays
+// small and unioning them to count distinct servers is cheap.
 
 const HOUR = 60 * 60 * 1000;
 const DAY = 24 * HOUR;


### PR DESCRIPTION
The status-page "servers" figure was counting distinct **WC3 realms** (`lobby.server`, e.g. `us`/`eu`/`kr`) of echoed lobbies. The intent is the number of distinct **Discord servers (guilds)** we actually posted lobbies to in the window.

## Change
- Derive the destination guild from each posted message's alert `meta.guildId` (falling back to the channel for DMs, which have no guild).
- Union those per time bucket so "X lobbies across Y servers" reads as X lobbies across Y Discord servers.

## Verification
- `deno check`, `deno lint`, `deno fmt` → all pass

https://claude.ai/code/session_01Q5ajSvRJDP1UUu7EHybdzL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5ajSvRJDP1UUu7EHybdzL)_