### PR TITLE
feat: 90-day uptime stripes + rename usage metric to "messages"

### DIFF
--- a/src/api/routes/getStatus.ts
+++ b/src/api/routes/getStatus.ts
@@ -1,6 +1,7 @@
 import { getCachedLobbies, stats } from "../../liveLobbies.ts";
 import { getSourceLiveness, Lobby } from "../../sources/lobbies.ts";
 import { getMetricsSummary, MetricsWindow } from "../../sources/metrics.ts";
+import { getUptimeSummary, ServiceUptime } from "../../sources/uptime.ts";
 import { Handler } from "../types.ts";
 
 export const formatTime = (
@@ -41,12 +42,44 @@ const lobbySort = (a: Lobby, b: Lobby) =>
 
 export const metricsHTML = (metrics: MetricsWindow[]) =>
   metrics.map((m) =>
-    `<div class="metric"><span class="metric-label">${m.label}</span><span class="metric-val">${m.lobbies.toLocaleString()} lobbies</span><span class="metric-sub">${m.servers.toLocaleString()} servers &middot; ${m.updates.toLocaleString()} updates</span></div>`
+    `<div class="metric"><span class="metric-label">${m.label}</span><span class="metric-val">${m.messages.toLocaleString()} messages</span><span class="metric-sub">${m.servers.toLocaleString()} servers &middot; ${m.updates.toLocaleString()} updates</span></div>`
   ).join("");
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export const uptimeHTML = (services: ServiceUptime[]) =>
+  services.map((s) => {
+    const pct = s.overallTotal
+      ? (s.overallUp / s.overallTotal * 100).toFixed(2) + "%"
+      : "&mdash;";
+    const bars = s.days.map((d) => {
+      const date = new Date(d.day * DAY_MS).toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        timeZone: "UTC",
+      });
+      const ratio = d.total ? d.up / d.total : 0;
+      const cls = !d.total
+        ? "nodata"
+        : ratio >= 0.99
+        ? "up"
+        : ratio >= 0.7
+        ? "warn"
+        : "down";
+      const title = d.total
+        ? `${date}: ${(ratio * 100).toFixed(2)}% up`
+        : `${date}: no data`;
+      return `<span class="ubar ${cls}" title="${title}"></span>`;
+    }).join("");
+    return `<div class="uptime-row"><div class="uptime-head"><span class="uptime-label">${s.label}</span><span class="uptime-pct">${pct}</span></div><div class="uptime-bars">${bars}</div></div>`;
+  }).join("");
 
 export const getStatus: Handler = async () => {
   const liveness = getSourceLiveness();
-  const metrics = await getMetricsSummary();
+  const [metrics, uptime] = await Promise.all([
+    getMetricsSummary(),
+    getUptimeSummary(),
+  ]);
   const allLobbies = [...getCachedLobbies()].sort(lobbySort);
   const lobbies = allLobbies.slice(0, 100);
 
@@ -95,6 +128,21 @@ export const getStatus: Handler = async () => {
     display: block; font-size: 11px; color: #666; margin-top: 2px;
     font-variant-numeric: tabular-nums;
   }
+  .uptime { margin-bottom: 24px }
+  .uptime-row { margin-bottom: 12px }
+  .uptime-row:last-child { margin-bottom: 0 }
+  .uptime-head {
+    display: flex; justify-content: space-between; align-items: baseline;
+    font-size: 12px; margin-bottom: 5px;
+  }
+  .uptime-label { color: #ccc }
+  .uptime-pct { color: #888; font-variant-numeric: tabular-nums }
+  .uptime-bars { display: flex; gap: 2px; height: 28px }
+  .ubar { flex: 1 1 0; min-width: 2px; border-radius: 1px; background: #2a2a2a }
+  .ubar.up { background: #4ec97a }
+  .ubar.warn { background: #e6a500 }
+  .ubar.down { background: #e05252 }
+  .ubar.nodata { background: #2a2a2a }
   table { width: 100%; border-collapse: collapse; table-layout: fixed }
   thead { position: sticky; top: 0; z-index: 1; background: #111 }
   th {
@@ -410,6 +458,7 @@ export const getStatus: Handler = async () => {
     <span>Lobbies: <span id="lobbyCount">${allLobbies.length}</span></span>
   </div>
   <div class="metrics" id="metrics">${metricsHTML(metrics)}</div>
+  <div class="uptime">${uptimeHTML(uptime)}</div>
   <table>
     <thead>
       <tr class="col-headers">

--- a/src/liveLobbies.ts
+++ b/src/liveLobbies.ts
@@ -1,6 +1,7 @@
 import {
   DataSource,
   getLobbies,
+  getSourceLiveness,
   Lobby,
   restoreDataSource,
   setOnDataSourceChange,
@@ -12,6 +13,7 @@ import { AllowedMentionsTypes, APIEmbed } from "discord-api-types/v10";
 import { getReplayMap, getReplays } from "./sources/replays.ts";
 import { notifyHealthy, notifyReady } from "./sources/watchdog.ts";
 import { recordMetrics } from "./sources/metrics.ts";
+import { recordUptime } from "./sources/uptime.ts";
 import { renderMessage } from "./template.ts";
 
 export const stats = { lastDataUpdate: 0 };
@@ -177,7 +179,7 @@ const updateMessage = async (
   dataSource: DataSource,
   alert: Alert | undefined,
   replayId?: number,
-) => {
+): Promise<boolean> => {
   try {
     if (status === "alive" || status === "missing") {
       const channelThrottle = channelThrottles[channel] ??
@@ -193,7 +195,7 @@ const updateMessage = async (
           "in channel",
           channel,
         );
-        return;
+        return false;
       }
       channelThrottle.bucket--;
       channelThrottle.lastUpdate = Date.now();
@@ -211,6 +213,7 @@ const updateMessage = async (
       status,
       `${lobby.slotsTaken}/${lobby.slotsTotal}`,
     );
+    return true;
   } catch (err) {
     if (!(err instanceof DiscordAPIError)) {
       console.error("Error updating message in channel", channel, err);
@@ -218,17 +221,20 @@ const updateMessage = async (
       console.warn(new Date(), "Message deleted in channel", channel);
       lobby.messages = lobby.messages.filter((m) => m.message !== message);
     } else console.error("Error updating message in channel", channel, err);
+    return false;
   }
 };
 
+// Returns the number of messages actually edited (excludes throttle-shed and
+// failed edits) so callers can count the work emitted.
 const onUpdateLobby = async (
   lobby: Lobby,
   dataSource: DataSource,
   alerts: Alert[],
-) => {
+): Promise<number> => {
   console.debug(new Date(), "Updating lobby", lobby.name);
   stats.lastDataUpdate = Date.now();
-  await Promise.all(
+  const edited = await Promise.all(
     lobby.messages.map(({ channel, message }) =>
       updateMessage(
         channel,
@@ -240,6 +246,7 @@ const onUpdateLobby = async (
       )
     ),
   );
+  return edited.filter(Boolean).length;
 };
 
 const onMissingLobby = async (
@@ -344,6 +351,9 @@ const updateLobbies = async () => {
     getReplays().catch(() => []),
   ]);
 
+  // Heartbeat for uptime tracking; runs every cycle regardless of lobby results.
+  await recordUptime(getSourceLiveness());
+
   if (newLobbies.length === 0) {
     // Don't mass update lobbies to missing if we have none
     notifyHealthy();
@@ -361,10 +371,10 @@ const updateLobbies = async () => {
   let pendingReplay = 0;
   let cleared = 0;
   let linked = 0;
-  // Metrics only count work we actually emit to Discord: lobbies we echoed to at
-  // least one channel and updates that edited at least one live message.
-  // echoedServers tracks the distinct Discord servers (guilds) we posted to.
-  let echoedLobbies = 0;
+  // Metrics count work we actually emit to Discord: each message posted and each
+  // live-update edit sent (excluding throttle-shed/failed edits). echoedServers
+  // tracks the distinct Discord servers (guilds) we posted to.
+  let echoedMessages = 0;
   let echoedUpdates = 0;
   const echoedServers = new Set<string>();
 
@@ -382,26 +392,24 @@ const updateLobbies = async () => {
     if (!oldLobby) {
       newLobby.messages = await onNewLobby(newLobby, alerts, dataSource);
       news++;
-      if (newLobby.messages.length) {
-        echoedLobbies++;
-        for (const { channel } of newLobby.messages) {
-          const meta = alerts.find((a) => a.channelId === channel)?.meta;
-          // Count distinct guilds we posted to; DMs have no guild, so fall back
-          // to the channel as the destination key.
-          echoedServers.add(
-            meta?.type === "guildChannel" ? meta.guildId : channel,
-          );
-        }
+      echoedMessages += newLobby.messages.length;
+      for (const { channel } of newLobby.messages) {
+        const meta = alerts.find((a) => a.channelId === channel)?.meta;
+        // Count distinct guilds we posted to; DMs have no guild, so fall back
+        // to the channel as the destination key.
+        echoedServers.add(
+          meta?.type === "guildChannel" ? meta.guildId : channel,
+        );
       }
       await setLobby(newLobby);
     } else {
       newLobby.messages = oldLobby.messages;
       if ((newLobby.slotsTaken !== oldLobby.slotsTaken) || oldLobby.deadAt) {
-        await onUpdateLobby(newLobby, dataSource, alerts);
+        const edited = await onUpdateLobby(newLobby, dataSource, alerts);
         if (oldLobby.deadAt) found++;
         else {
           updates++;
-          if (newLobby.messages.length) echoedUpdates++;
+          echoedUpdates += edited;
         }
       } else stable++;
       await setLobby(newLobby);
@@ -500,7 +508,7 @@ const updateLobbies = async () => {
   );
 
   await recordMetrics({
-    lobbies: echoedLobbies,
+    messages: echoedMessages,
     updates: echoedUpdates,
     servers: [...echoedServers],
   });

--- a/src/sources/metrics.ts
+++ b/src/sources/metrics.ts
@@ -1,6 +1,6 @@
 import { kv } from "./kv.ts";
 
-// Cheap usage metrics: how many lobbies were posted, how many updates we sent,
+// Cheap usage metrics: how many messages we posted, how many updates we sent,
 // and across how many distinct Discord servers — bucketed over a handful of
 // rolling time windows for the status page.
 //
@@ -17,16 +17,16 @@ const DAY = 24 * HOUR;
 const HOURS_KEPT = 48; // covers the 24h window
 const DAYS_KEPT = 400; // covers the 365d window
 
-type Bucket = { lobbies: number; updates: number; servers: string[] };
+type Bucket = { messages: number; updates: number; servers: string[] };
 
-const empty = (): Bucket => ({ lobbies: 0, updates: 0, servers: [] });
+const empty = (): Bucket => ({ messages: 0, updates: 0, servers: [] });
 
 const hourKey = (index: number) => ["metrics", "hour", index];
 const dayKey = (index: number) => ["metrics", "day", index];
 const allKey = ["metrics", "all"];
 
 const merge = (base: Bucket, add: Bucket): Bucket => ({
-  lobbies: base.lobbies + add.lobbies,
+  messages: base.messages + add.messages,
   updates: base.updates + add.updates,
   servers: [...new Set([...base.servers, ...add.servers])],
 });
@@ -51,13 +51,13 @@ const pruneOld = async (hour: number, day: number) => {
 };
 
 /**
- * Record a cycle's worth of activity. `servers` should be the realms of the
- * lobbies counted in `lobbies`. No-ops when there's nothing to record.
+ * Record a cycle's worth of activity. `servers` should be the Discord servers
+ * the counted `messages` were posted to. No-ops when there's nothing to record.
  */
 export const recordMetrics = async (
-  add: { lobbies: number; updates: number; servers: string[] },
+  add: { messages: number; updates: number; servers: string[] },
 ) => {
-  if (!add.lobbies && !add.updates) return;
+  if (!add.messages && !add.updates) return;
   try {
     const now = Date.now();
     const hour = Math.floor(now / HOUR);
@@ -70,7 +70,7 @@ export const recordMetrics = async (
     ]);
 
     const sample: Bucket = {
-      lobbies: add.lobbies,
+      messages: add.messages,
       updates: add.updates,
       servers: [...new Set(add.servers)],
     };
@@ -91,7 +91,7 @@ export const recordMetrics = async (
 
 export type MetricsWindow = {
   label: string;
-  lobbies: number;
+  messages: number;
   updates: number;
   servers: number;
 };
@@ -139,23 +139,23 @@ export const getMetricsSummary = async (): Promise<MetricsWindow[]> => {
       const cutoff = Math.floor((now - ms) / size);
       const source = byDay ? daily : hourly;
 
-      let lobbies = 0;
+      let messages = 0;
       let updates = 0;
       const servers = new Set<string>();
       for (const [index, b] of source) {
         if (index < cutoff) continue;
-        lobbies += b.lobbies;
+        messages += b.messages;
         updates += b.updates;
         for (const s of b.servers) servers.add(s);
       }
-      return { label, lobbies, updates, servers: servers.size };
+      return { label, messages, updates, servers: servers.size };
     },
   );
 
   const allB = all.value ?? empty();
   summary.push({
     label: "All",
-    lobbies: allB.lobbies,
+    messages: allB.messages,
     updates: allB.updates,
     servers: allB.servers.length,
   });

--- a/src/sources/uptime.ts
+++ b/src/sources/uptime.ts
@@ -1,0 +1,188 @@
+import { kv } from "./kv.ts";
+
+// Uptime tracking for the classic 90-day status stripe. For each service we
+// accumulate, per UTC day, how many ms it was up and how many ms we observed it
+// — so a day's uptime is up/total and the headline figure is the sum over the
+// window.
+//
+// The bot can't record while it's down, so we measure its uptime from the gap
+// between heartbeats: each cycle we attribute the elapsed time since the last
+// beat as "up", unless the gap is too large (a restart/outage), in which case
+// only a small grace window counts as up and the rest is downtime.
+//
+// wc3stats / wc3maps are only credited time we actually observed them. We don't
+// probe wc3maps while wc3stats is online, so on days that stayed on wc3stats the
+// wc3maps total is simply zero (shown as "no data"), which is the intended
+// caveat.
+
+const DAY = 24 * 60 * 60 * 1000;
+// Largest gap between heartbeats still treated as the bot being up. Cycles run
+// every ~10s and always finish within the 60s watchdog, so a gap beyond this
+// means the process was actually down.
+const MAX_GAP = 90 * 1000;
+const DAYS_SHOWN = 90;
+const DAYS_KEPT = DAYS_SHOWN + 2;
+
+const services = [
+  { key: "bot", label: "Bot" },
+  { key: "wc3stats", label: "wc3stats" },
+  { key: "wc3maps", label: "wc3maps" },
+] as const;
+
+type Day = { up: number; total: number };
+
+const beatKey = ["uptime", "lastBeat"];
+
+// Split [start, end) across UTC-day buckets, adding the per-day overlap to the
+// given field.
+const addInterval = (
+  deltas: Map<number, Day>,
+  start: number,
+  end: number,
+  field: "up" | "total",
+) => {
+  for (let s = start; s < end;) {
+    const day = Math.floor(s / DAY);
+    const dayEnd = (day + 1) * DAY;
+    const slice = Math.min(end, dayEnd) - s;
+    const d = deltas.get(day) ?? { up: 0, total: 0 };
+    d[field] += slice;
+    deltas.set(day, d);
+    s = dayEnd;
+  }
+};
+
+const accrue = async (
+  service: string,
+  totalStart: number,
+  totalEnd: number,
+  upStart: number,
+  upEnd: number,
+) => {
+  const deltas = new Map<number, Day>();
+  addInterval(deltas, totalStart, totalEnd, "total");
+  if (upEnd > upStart) addInterval(deltas, upStart, upEnd, "up");
+  await Promise.all(
+    [...deltas].map(async ([day, d]) => {
+      const key = ["uptime", service, day];
+      const cur = (await kv.get<Day>(key)).value ?? { up: 0, total: 0 };
+      await kv.set(key, { up: cur.up + d.up, total: cur.total + d.total });
+    }),
+  );
+};
+
+const prune = async (today: number) => {
+  try {
+    const stale: Deno.KvKey[] = [];
+    for (const { key: service } of services) {
+      for await (
+        const e of kv.list({ prefix: ["uptime", service] }, { batchSize: 500 })
+      ) {
+        const day = e.key.at(-1);
+        if (typeof day === "number" && day < today - DAYS_KEPT) {
+          stale.push(e.key);
+        }
+      }
+    }
+    await Promise.all(stale.map((k) => kv.delete(k)));
+  } catch (err) {
+    console.error(new Date(), "Failed to prune uptime buckets", err);
+  }
+};
+
+type Liveness = {
+  wc3statsUp: boolean;
+  wc3mapsUp: boolean;
+  wc3mapsChecked: boolean;
+};
+
+/**
+ * Heartbeat. Call once per update cycle with the freshly observed source
+ * liveness. Attributes the time since the last beat to the bot, wc3stats, and
+ * (when checked) wc3maps.
+ */
+export const recordUptime = async (liveness: Liveness, now = Date.now()) => {
+  try {
+    const lastBeat = (await kv.get<number>(beatKey)).value;
+    await kv.set(beatKey, now);
+    // First beat ever, or a clock that went backwards: nothing to attribute.
+    if (typeof lastBeat !== "number" || now <= lastBeat) return;
+
+    // The window we trust as observed: from the last beat up to a grace cap.
+    // For a normal cycle this is the whole gap; after an outage it's just the
+    // grace window and the rest of the gap is the bot's downtime.
+    const coveredEnd = Math.min(now, lastBeat + MAX_GAP);
+
+    await Promise.all([
+      // Bot: the whole gap counts toward total, only the covered part as up.
+      accrue("bot", lastBeat, now, lastBeat, coveredEnd),
+      // Sources: only credit time we actually observed (the covered window).
+      accrue(
+        "wc3stats",
+        lastBeat,
+        coveredEnd,
+        lastBeat,
+        liveness.wc3statsUp ? coveredEnd : lastBeat,
+      ),
+      liveness.wc3mapsChecked
+        ? accrue(
+          "wc3maps",
+          lastBeat,
+          coveredEnd,
+          lastBeat,
+          liveness.wc3mapsUp ? coveredEnd : lastBeat,
+        )
+        : Promise.resolve(),
+    ]);
+
+    // Sweep expired buckets once a day, when the day rolls over.
+    if (Math.floor(lastBeat / DAY) !== Math.floor(now / DAY)) {
+      await prune(Math.floor(now / DAY));
+    }
+  } catch (err) {
+    console.error(new Date(), "Failed to record uptime", err);
+  }
+};
+
+export type UptimeDay = { day: number; up: number; total: number };
+export type ServiceUptime = {
+  label: string;
+  days: UptimeDay[];
+  overallUp: number;
+  overallTotal: number;
+};
+
+let cache: { at: number; summary: ServiceUptime[] } | undefined;
+const CACHE_MS = 60_000;
+
+/** Per-service uptime over the last DAYS_SHOWN days. Cached for a minute. */
+export const getUptimeSummary = async (): Promise<ServiceUptime[]> => {
+  if (cache && Date.now() - cache.at < CACHE_MS) return cache.summary;
+
+  const today = Math.floor(Date.now() / DAY);
+  const start = today - (DAYS_SHOWN - 1);
+
+  const summary = await Promise.all(services.map(async ({ key, label }) => {
+    const buckets = new Map<number, Day>();
+    for await (
+      const e of kv.list<Day>({ prefix: ["uptime", key] }, { batchSize: 500 })
+    ) {
+      const day = e.key.at(-1);
+      if (typeof day === "number") buckets.set(day, e.value);
+    }
+
+    const days: UptimeDay[] = [];
+    let overallUp = 0;
+    let overallTotal = 0;
+    for (let d = start; d <= today; d++) {
+      const b = buckets.get(d) ?? { up: 0, total: 0 };
+      days.push({ day: d, up: b.up, total: b.total });
+      overallUp += b.up;
+      overallTotal += b.total;
+    }
+    return { label, days, overallUp, overallTotal };
+  }));
+
+  cache = { at: Date.now(), summary };
+  return summary;
+};


### PR DESCRIPTION
## Uptime
Adds the classic 90-day green/yellow/red uptime stripe to the status page for three services — **Bot**, **wc3stats**, **wc3maps** — each with an overall uptime % over the window.

- New `uptime` module accumulates, per UTC day, how many ms each service was **up** vs **observed**, in Deno KV. A day's color: green ≥99%, yellow ≥70%, red below; gray = no data.
- **Bot** uptime is derived from heartbeat gaps (it can't record while down): each cycle credits elapsed time as up, unless the gap exceeds a 90s grace cap — then the excess counts as downtime. `lastBeat` is persisted so outages across restarts are captured.
- **wc3stats/wc3maps** are only credited time we actually observed them. Since wc3maps isn't probed while wc3stats is online, days that stayed on wc3stats show as **"no data"** for wc3maps rather than counting against it (the requested caveat).
- The heartbeat runs every update cycle, including the no-lobbies path.

## Metric rename
Renames the usage metric from **"lobbies"** to **"messages"** and counts **per emitted message/edit** — a lobby posted to 3 channels is 3 messages, and update edits are counted the same way (throttle-shed and failed edits excluded). So it reflects work the bot actually emits to Discord. Reads "N messages · Y servers · Z updates".

## Verification
- Deterministic test of the gap/day-bucketing logic (bot downtime, wc3stats down cycle, wc3maps only-when-checked) → all expected values.
- `deno fmt` / `deno lint` / `deno check` → pass
- `deno test` → 29 passed

Preview of the rendered page (sample data) was shared in the session.

https://claude.ai/code/session_01Q5ajSvRJDP1UUu7EHybdzL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5ajSvRJDP1UUu7EHybdzL)_