### PR TITLE
fix: NaN metric counts from old buckets + pretty uptime day tooltips

### DIFF
--- a/src/api/routes/getStatus.ts
+++ b/src/api/routes/getStatus.ts
@@ -47,6 +47,13 @@ export const metricsHTML = (metrics: MetricsWindow[]) =>
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+const fmtDuration = (ms: number) => {
+  const minutes = Math.round(ms / 60000);
+  if (minutes < 60) return `${minutes}m`;
+  if (minutes < 60 * 24) return `${Math.round(minutes / 6) / 10}h`;
+  return `${Math.round(minutes / 144) / 10}d`;
+};
+
 export const uptimeHTML = (services: ServiceUptime[]) =>
   services.map((s) => {
     const pct = s.overallTotal
@@ -66,10 +73,13 @@ export const uptimeHTML = (services: ServiceUptime[]) =>
         : ratio >= 0.7
         ? "warn"
         : "down";
-      const title = d.total
-        ? `${date}: ${(ratio * 100).toFixed(2)}% up`
-        : `${date}: no data`;
-      return `<span class="ubar ${cls}" title="${title}"></span>`;
+      const downMs = d.total - d.up;
+      const tip = d.total
+        ? `<strong>${date}</strong>${(ratio * 100).toFixed(2)}% uptime${
+          downMs >= 60000 ? ` &middot; ${fmtDuration(downMs)} down` : ""
+        }`
+        : `<strong>${date}</strong>Not monitored`;
+      return `<span class="ubar ${cls}"><span class="utip">${tip}</span></span>`;
     }).join("");
     return `<div class="uptime-row"><div class="uptime-head"><span class="uptime-label">${s.label}</span><span class="uptime-pct">${pct}</span></div><div class="uptime-bars">${bars}</div></div>`;
   }).join("");
@@ -138,11 +148,51 @@ export const getStatus: Handler = async () => {
   .uptime-label { color: #ccc }
   .uptime-pct { color: #888; font-variant-numeric: tabular-nums }
   .uptime-bars { display: flex; gap: 2px; height: 28px }
-  .ubar { flex: 1 1 0; min-width: 2px; border-radius: 1px; background: #2a2a2a }
+  .ubar {
+    position: relative;
+    flex: 1 1 0; min-width: 2px; border-radius: 1px; background: #2a2a2a;
+    transition: transform 0.08s ease;
+  }
   .ubar.up { background: #4ec97a }
   .ubar.warn { background: #e6a500 }
   .ubar.down { background: #e05252 }
   .ubar.nodata { background: #2a2a2a }
+  .ubar:hover { transform: scaleY(1.12) }
+  .utip {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    display: none;
+    padding: 6px 10px;
+    background: #1d1d1d;
+    border: 1px solid #333;
+    border-radius: 6px;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.55);
+    font-size: 11px;
+    line-height: 1.5;
+    color: #aaa;
+    white-space: nowrap;
+    text-align: center;
+    pointer-events: none;
+    z-index: 10;
+  }
+  .utip strong {
+    display: block;
+    color: #fff;
+    font-weight: 500;
+    margin-bottom: 1px;
+  }
+  .utip::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 5px solid transparent;
+    border-top-color: #333;
+  }
+  .ubar:hover .utip { display: block }
   table { width: 100%; border-collapse: collapse; table-layout: fixed }
   thead { position: sticky; top: 0; z-index: 1; background: #111 }
   th {

--- a/src/sources/metrics.ts
+++ b/src/sources/metrics.ts
@@ -19,7 +19,14 @@ const DAYS_KEPT = 400; // covers the 365d window
 
 type Bucket = { messages: number; updates: number; servers: string[] };
 
-const empty = (): Bucket => ({ messages: 0, updates: 0, servers: [] });
+// Buckets written before the "lobbies" -> "messages" rename stored a `lobbies`
+// field; coalesce so existing data carries over instead of reading as NaN.
+type StoredBucket = Partial<Bucket> & { lobbies?: number };
+const normalize = (v: StoredBucket | null | undefined): Bucket => ({
+  messages: v?.messages ?? v?.lobbies ?? 0,
+  updates: v?.updates ?? 0,
+  servers: v?.servers ?? [],
+});
 
 const hourKey = (index: number) => ["metrics", "hour", index];
 const dayKey = (index: number) => ["metrics", "day", index];
@@ -64,9 +71,9 @@ export const recordMetrics = async (
     const day = Math.floor(now / DAY);
 
     const [hourB, dayB, allB] = await Promise.all([
-      kv.get<Bucket>(hourKey(hour)),
-      kv.get<Bucket>(dayKey(day)),
-      kv.get<Bucket>(allKey),
+      kv.get<StoredBucket>(hourKey(hour)),
+      kv.get<StoredBucket>(dayKey(day)),
+      kv.get<StoredBucket>(allKey),
     ]);
 
     const sample: Bucket = {
@@ -76,9 +83,9 @@ export const recordMetrics = async (
     };
 
     await Promise.all([
-      kv.set(hourKey(hour), merge(hourB.value ?? empty(), sample)),
-      kv.set(dayKey(day), merge(dayB.value ?? empty(), sample)),
-      kv.set(allKey, merge(allB.value ?? empty(), sample)),
+      kv.set(hourKey(hour), merge(normalize(hourB.value), sample)),
+      kv.set(dayKey(day), merge(normalize(dayB.value), sample)),
+      kv.set(allKey, merge(normalize(allB.value), sample)),
     ]);
 
     // A freshly created hour bucket means the clock rolled over — a good, cheap
@@ -109,8 +116,8 @@ const readBuckets = async (
   prefix: Deno.KvKey,
 ): Promise<Map<number, Bucket>> => {
   const map = new Map<number, Bucket>();
-  for await (const e of kv.list<Bucket>({ prefix }, { batchSize: 500 })) {
-    map.set(e.key.at(-1) as number, e.value);
+  for await (const e of kv.list<StoredBucket>({ prefix }, { batchSize: 500 })) {
+    map.set(e.key.at(-1) as number, normalize(e.value));
   }
   return map;
 };
@@ -130,7 +137,7 @@ export const getMetricsSummary = async (): Promise<MetricsWindow[]> => {
   const [hourly, daily, all] = await Promise.all([
     readBuckets(["metrics", "hour"]),
     readBuckets(["metrics", "day"]),
-    kv.get<Bucket>(allKey),
+    kv.get<StoredBucket>(allKey),
   ]);
 
   const summary: MetricsWindow[] = windows.map(
@@ -152,7 +159,7 @@ export const getMetricsSummary = async (): Promise<MetricsWindow[]> => {
     },
   );
 
-  const allB = all.value ?? empty();
+  const allB = normalize(all.value);
   summary.push({
     label: "All",
     messages: allB.messages,


### PR DESCRIPTION
## NaN messages
Metric buckets written before the `lobbies` → `messages` rename stored a `lobbies` field, so reads landed on `undefined` and summed to `NaN` (and the `All` window could throw). Buckets are now normalized on read, coalescing the old `lobbies` value into `messages`, so existing data carries over cleanly.

## Pretty per-day hover
Replaces the uptime day bars' `title` attribute with a styled tooltip: bold date, `XX.XX% uptime`, and `· Nm/h/d down` when the day was degraded (or "Not monitored" for no-data days). Bars also lift slightly on hover. No `title` anymore.

## Verification
- Test: feeding old-shape (`lobbies`) buckets → summary returns real numbers, not NaN.
- `deno fmt` / `deno lint` / `deno check` pass; `deno test` 29 passed.

https://claude.ai/code/session_01Q5ajSvRJDP1UUu7EHybdzL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5ajSvRJDP1UUu7EHybdzL)_