### PR TITLE
fix: repair NaN metric buckets in KV + rename uptime "Bot" to "Live Lobbies"

### DIFF
--- a/src/liveLobbies.ts
+++ b/src/liveLobbies.ts
@@ -12,7 +12,7 @@ import { DiscordAPIError } from "@discordjs/rest";
 import { AllowedMentionsTypes, APIEmbed } from "discord-api-types/v10";
 import { getReplayMap, getReplays } from "./sources/replays.ts";
 import { notifyHealthy, notifyReady } from "./sources/watchdog.ts";
-import { recordMetrics } from "./sources/metrics.ts";
+import { recordMetrics, repairMetrics } from "./sources/metrics.ts";
 import { recordUptime } from "./sources/uptime.ts";
 import { renderMessage } from "./template.ts";
 
@@ -557,6 +557,9 @@ if (!Deno.env.get("DISABLE_LIVE_LOBBIES")) {
   });
   const restored = await meta.getDataSource();
   if (restored) restoreDataSource(restored);
+
+  // One-time cleanup of metric buckets corrupted by the lobbies->messages rename.
+  repairMetrics();
 
   Deno.cron("lobbies", "* * * * *", () => {
     if (!armed) {

--- a/src/sources/metrics.ts
+++ b/src/sources/metrics.ts
@@ -20,13 +20,47 @@ const DAYS_KEPT = 400; // covers the 365d window
 type Bucket = { messages: number; updates: number; servers: string[] };
 
 // Buckets written before the "lobbies" -> "messages" rename stored a `lobbies`
-// field; coalesce so existing data carries over instead of reading as NaN.
+// field; coalesce so existing data carries over. We also guard against NaN: an
+// earlier build summed undefined fields and persisted NaN into KV, and NaN is
+// not caught by `??`, so check for finiteness explicitly.
 type StoredBucket = Partial<Bucket> & { lobbies?: number };
+const fin = (x: unknown): number | undefined =>
+  typeof x === "number" && Number.isFinite(x) ? x : undefined;
 const normalize = (v: StoredBucket | null | undefined): Bucket => ({
-  messages: v?.messages ?? v?.lobbies ?? 0,
-  updates: v?.updates ?? 0,
+  messages: fin(v?.messages) ?? fin(v?.lobbies) ?? 0,
+  updates: fin(v?.updates) ?? 0,
   servers: v?.servers ?? [],
 });
+
+/**
+ * One-time cleanup: rewrite any bucket still holding a legacy `lobbies` field or
+ * a non-finite (NaN) count, so the stored data matches the current shape.
+ * Idempotent and cheap — clean buckets are skipped.
+ */
+export const repairMetrics = async () => {
+  try {
+    let fixed = 0;
+    for await (
+      const e of kv.list<StoredBucket>(
+        { prefix: ["metrics"] },
+        { batchSize: 500 },
+      )
+    ) {
+      const v = e.value;
+      if (
+        v?.lobbies !== undefined ||
+        !Number.isFinite(v?.messages) ||
+        !Number.isFinite(v?.updates)
+      ) {
+        await kv.set(e.key, normalize(v));
+        fixed++;
+      }
+    }
+    if (fixed) console.log(new Date(), "Repaired", fixed, "metric buckets");
+  } catch (err) {
+    console.error(new Date(), "Failed to repair metrics", err);
+  }
+};
 
 const hourKey = (index: number) => ["metrics", "hour", index];
 const dayKey = (index: number) => ["metrics", "day", index];

--- a/src/sources/uptime.ts
+++ b/src/sources/uptime.ts
@@ -24,7 +24,7 @@ const DAYS_SHOWN = 90;
 const DAYS_KEPT = DAYS_SHOWN + 2;
 
 const services = [
-  { key: "bot", label: "Bot" },
+  { key: "bot", label: "Live Lobbies" },
   { key: "wc3stats", label: "wc3stats" },
   { key: "wc3maps", label: "wc3maps" },
 ] as const;


### PR DESCRIPTION
## Why NaN persisted
`??` only catches `null`/`undefined`, not `NaN`. An earlier build summed `undefined + number` and **persisted `NaN` into KV** (Deno KV preserves `NaN`), so PR #24's `normalize` passed it straight through.

## Fixes
- **`normalize` is now finite-safe**: non-finite counts are treated as missing, falling back to the legacy `lobbies` value or `0`. Reads no longer show NaN.
- **`repairMetrics()`** runs once on boot and rewrites any bucket still holding a legacy `lobbies` field or a NaN count, so the stored data is actually cleaned (idempotent; clean buckets skipped). NaN message counts can't be recovered (the original value was lost when it was corrupted), so they reset to 0; `updates` and `servers` are preserved, and legacy `lobbies` values are carried over to `messages`.
- **Rename** the uptime stripe label **"Bot" → "Live Lobbies"**.

## How your data gets fixed
Deploy + restart: `repairMetrics()` sweeps the buckets on startup (you'll see a `Repaired N metric buckets` log line). After that the stored data is clean.

## Verification
- Test: seeded NaN + legacy `lobbies` buckets → after repair, NaN→0 (updates/servers kept), `lobbies`→`messages`, summary all finite.
- `deno fmt`/`lint`/`check` pass; `deno test` 29 passed.

https://claude.ai/code/session_01Q5ajSvRJDP1UUu7EHybdzL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5ajSvRJDP1UUu7EHybdzL)_