### PR TITLE
fix: backfill all-time metric bucket from daily buckets on boot

### DIFF
--- a/src/sources/metrics.ts
+++ b/src/sources/metrics.ts
@@ -34,12 +34,19 @@ const normalize = (v: StoredBucket | null | undefined): Bucket => ({
 
 /**
  * One-time cleanup: rewrite any bucket still holding a legacy `lobbies` field or
- * a non-finite (NaN) count, so the stored data matches the current shape.
- * Idempotent and cheap — clean buckets are skipped.
+ * a non-finite (NaN) count, so the stored data matches the current shape. Also
+ * backfills the all-time bucket from the daily buckets if it's behind — the NaN
+ * repair reset it to zero, and since tracking just began the daily sum is the
+ * true all-time total. Idempotent and cheap.
  */
 export const repairMetrics = async () => {
   try {
     let fixed = 0;
+    let dailyMsgs = 0;
+    let dailyUpdates = 0;
+    const dailyServers = new Set<string>();
+    let allBucket: Bucket | null = null;
+
     for await (
       const e of kv.list<StoredBucket>(
         { prefix: ["metrics"] },
@@ -47,16 +54,41 @@ export const repairMetrics = async () => {
       )
     ) {
       const v = e.value;
+      const clean = normalize(v);
       if (
         v?.lobbies !== undefined ||
         !Number.isFinite(v?.messages) ||
         !Number.isFinite(v?.updates)
       ) {
-        await kv.set(e.key, normalize(v));
+        await kv.set(e.key, clean);
         fixed++;
+      }
+      if (e.key[1] === "day") {
+        dailyMsgs += clean.messages;
+        dailyUpdates += clean.updates;
+        for (const s of clean.servers) dailyServers.add(s);
+      } else if (e.key[1] === "all") {
+        allBucket = clean;
       }
     }
     if (fixed) console.log(new Date(), "Repaired", fixed, "metric buckets");
+
+    // Backfill the all-time bucket from daily data when it's behind. Max, never
+    // reduce, so it stays correct once old day buckets are pruned.
+    const cur = allBucket ?? { messages: 0, updates: 0, servers: [] };
+    const backfilled: Bucket = {
+      messages: Math.max(cur.messages, dailyMsgs),
+      updates: Math.max(cur.updates, dailyUpdates),
+      servers: [...new Set([...cur.servers, ...dailyServers])],
+    };
+    if (
+      backfilled.messages !== cur.messages ||
+      backfilled.updates !== cur.updates ||
+      backfilled.servers.length !== cur.servers.length
+    ) {
+      await kv.set(allKey, backfilled);
+      console.log(new Date(), "Backfilled all-time metric bucket from daily");
+    }
   } catch (err) {
     console.error(new Date(), "Failed to repair metrics", err);
   }


### PR DESCRIPTION
The NaN repair reset the corrupted all-time metric bucket to 0, so the "All" card shows 0 messages while the daily-backed windows (1y, etc.) have real data.

Since tracking only just began, the sum of the daily buckets *is* the true all-time total. `repairMetrics()` now reconstructs the all-time bucket from the daily buckets on boot — taking the per-field **max** so it's never reduced later once old day buckets age out of retention. Idempotent: once all-time ≥ the daily sum, subsequent boots leave it unchanged.

## How your data gets fixed
Deploy + restart — you'll see a `Backfilled all-time metric bucket from daily` log line, and the "All" card will then match the cumulative totals.

## Verification
- Test: daily buckets summing to 175 msgs / 480 updates / 3 servers + an all bucket of 0 → after repair the all bucket becomes 175 / 480 / 3, and a second run leaves it unchanged.
- `deno fmt`/`lint`/`check` pass; `deno test` 29 passed.

https://claude.ai/code/session_01Q5ajSvRJDP1UUu7EHybdzL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5ajSvRJDP1UUu7EHybdzL)_