### PR TITLE
fix: Live Lobbies uptime reflects feed availability, not just process liveness

### DIFF
--- a/src/api/routes/getStatus.ts
+++ b/src/api/routes/getStatus.ts
@@ -81,7 +81,10 @@ export const uptimeHTML = (services: ServiceUptime[]) =>
         : `<strong>${date}</strong>Not monitored`;
       return `<span class="ubar ${cls}"><span class="utip">${tip}</span></span>`;
     }).join("");
-    return `<div class="uptime-row"><div class="uptime-head"><span class="uptime-label">${s.label}</span><span class="uptime-pct">${pct}</span></div><div class="uptime-bars">${bars}</div></div>`;
+    const tag = s.note
+      ? `<span class="uptime-tag">fallback<span class="uptime-note">${s.note}</span></span>`
+      : "";
+    return `<div class="uptime-row"><div class="uptime-head"><span class="uptime-label">${s.label}${tag}</span><span class="uptime-pct">${pct}</span></div><div class="uptime-bars">${bars}</div></div>`;
   }).join("");
 
 export const getStatus: Handler = async () => {
@@ -193,6 +196,47 @@ export const getStatus: Handler = async () => {
     border-top-color: #333;
   }
   .ubar:hover .utip { display: block }
+  .uptime-tag {
+    position: relative;
+    margin-left: 7px;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #888;
+    border: 1px solid #333;
+    border-radius: 4px;
+    padding: 1px 5px;
+    cursor: help;
+  }
+  .uptime-note {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 0;
+    display: none;
+    width: 250px;
+    max-width: 70vw;
+    padding: 8px 10px;
+    background: #1d1d1d;
+    border: 1px solid #333;
+    border-radius: 6px;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.55);
+    font-size: 11px;
+    line-height: 1.5;
+    color: #aaa;
+    text-transform: none;
+    letter-spacing: normal;
+    z-index: 10;
+    pointer-events: none;
+  }
+  .uptime-note::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 16px;
+    border: 5px solid transparent;
+    border-top-color: #333;
+  }
+  .uptime-tag:hover .uptime-note { display: block }
   table { width: 100%; border-collapse: collapse; table-layout: fixed }
   thead { position: sticky; top: 0; z-index: 1; background: #111 }
   th {

--- a/src/sources/uptime.ts
+++ b/src/sources/uptime.ts
@@ -26,11 +26,17 @@ const MAX_GAP = 90 * 1000;
 const DAYS_SHOWN = 90;
 const DAYS_KEPT = DAYS_SHOWN + 2;
 
-const services = [
+const services: { key: string; label: string; note?: string }[] = [
   { key: "bot", label: "Live Lobbies" },
   { key: "wc3stats", label: "wc3stats" },
-  { key: "wc3maps", label: "wc3maps" },
-] as const;
+  {
+    key: "wc3maps",
+    label: "wc3maps",
+    note: "wc3maps is only checked while wc3stats is down, so this is its " +
+      "availability during those fallback periods — not its overall uptime, " +
+      "which we can't observe while wc3stats is up.",
+  },
+];
 
 type Day = { up: number; total: number };
 
@@ -154,6 +160,7 @@ export const recordUptime = async (liveness: Liveness, now = Date.now()) => {
 export type UptimeDay = { day: number; up: number; total: number };
 export type ServiceUptime = {
   label: string;
+  note?: string;
   days: UptimeDay[];
   overallUp: number;
   overallTotal: number;
@@ -169,26 +176,28 @@ export const getUptimeSummary = async (): Promise<ServiceUptime[]> => {
   const today = Math.floor(Date.now() / DAY);
   const start = today - (DAYS_SHOWN - 1);
 
-  const summary = await Promise.all(services.map(async ({ key, label }) => {
-    const buckets = new Map<number, Day>();
-    for await (
-      const e of kv.list<Day>({ prefix: ["uptime", key] }, { batchSize: 500 })
-    ) {
-      const day = e.key.at(-1);
-      if (typeof day === "number") buckets.set(day, e.value);
-    }
+  const summary = await Promise.all(
+    services.map(async ({ key, label, note }) => {
+      const buckets = new Map<number, Day>();
+      for await (
+        const e of kv.list<Day>({ prefix: ["uptime", key] }, { batchSize: 500 })
+      ) {
+        const day = e.key.at(-1);
+        if (typeof day === "number") buckets.set(day, e.value);
+      }
 
-    const days: UptimeDay[] = [];
-    let overallUp = 0;
-    let overallTotal = 0;
-    for (let d = start; d <= today; d++) {
-      const b = buckets.get(d) ?? { up: 0, total: 0 };
-      days.push({ day: d, up: b.up, total: b.total });
-      overallUp += b.up;
-      overallTotal += b.total;
-    }
-    return { label, days, overallUp, overallTotal };
-  }));
+      const days: UptimeDay[] = [];
+      let overallUp = 0;
+      let overallTotal = 0;
+      for (let d = start; d <= today; d++) {
+        const b = buckets.get(d) ?? { up: 0, total: 0 };
+        days.push({ day: d, up: b.up, total: b.total });
+        overallUp += b.up;
+        overallTotal += b.total;
+      }
+      return { label, note, days, overallUp, overallTotal };
+    }),
+  );
 
   cache = { at: Date.now(), summary };
   return summary;

--- a/src/sources/uptime.ts
+++ b/src/sources/uptime.ts
@@ -34,7 +34,7 @@ const services: { key: string; label: string; note?: string }[] = [
     label: "wc3maps",
     note: "wc3maps is only checked while wc3stats is down, so this is its " +
       "availability during those fallback periods — not its overall uptime, " +
-      "which we can't observe while wc3stats is up.",
+      "which we don't observe while wc3stats is up.",
   },
 ];
 

--- a/src/sources/uptime.ts
+++ b/src/sources/uptime.ts
@@ -5,10 +5,13 @@ import { kv } from "./kv.ts";
 // — so a day's uptime is up/total and the headline figure is the sum over the
 // window.
 //
-// The bot can't record while it's down, so we measure its uptime from the gap
-// between heartbeats: each cycle we attribute the elapsed time since the last
+// The bot ("Live Lobbies") can't record while it's down, so we measure from the
+// gap between heartbeats: each cycle attributes the elapsed time since the last
 // beat as "up", unless the gap is too large (a restart/outage), in which case
-// only a small grace window counts as up and the rest is downtime.
+// only a small grace window counts and the rest is downtime. "Up" also requires
+// a feed to be available — if both wc3stats and wc3maps are down the bot can't
+// serve lobbies, so that counts as downtime even though the process is alive.
+// This makes Live Lobbies the OR of the two feeds (plus process liveness).
 //
 // wc3stats / wc3maps are only credited time we actually observed them. We don't
 // probe wc3maps while wc3stats is online, so on days that stayed on wc3stats the
@@ -113,9 +116,13 @@ export const recordUptime = async (liveness: Liveness, now = Date.now()) => {
     // grace window and the rest of the gap is the bot's downtime.
     const coveredEnd = Math.min(now, lastBeat + MAX_GAP);
 
+    // The lobby service is functional whenever a feed is available; if both are
+    // down (or the process is) it can't serve lobbies, so that's downtime.
+    const feedUp = liveness.wc3statsUp || liveness.wc3mapsUp;
+
     await Promise.all([
-      // Bot: the whole gap counts toward total, only the covered part as up.
-      accrue("bot", lastBeat, now, lastBeat, coveredEnd),
+      // Live Lobbies: up = process alive (covered window) AND a feed available.
+      accrue("bot", lastBeat, now, lastBeat, feedUp ? coveredEnd : lastBeat),
       // Sources: only credit time we actually observed (the covered window).
       accrue(
         "wc3stats",


### PR DESCRIPTION
## The bug
"Live Lobbies" uptime was measuring only **process liveness** (the heartbeat), so it read ~100% even when both feeds were down and no lobbies could actually be served. That's why it showed 100% while wc3stats sat at 77.85% and wc3maps at 99.69%.

## Fix
A cycle now counts as "up" only when the process is alive **and** a feed is available (`wc3stats OR wc3maps`). So Live Lobbies is the OR of the two feeds plus process liveness — it sits *above* each feed individually and only dips when **both** feeds are down at once.

With the reported numbers that's ~`77.85% + 22.15%×99.69% ≈ 99.93%`, not 100%.

## Verification
Simulated 1000 cycles (wc3stats down ~22%, wc3maps down on one of those cycles → exactly one both-down cycle):
- Live Lobbies **99.90%** (not 100%, and above both feeds)
- wc3stats 77.80%
- wc3maps 99.55%

`deno fmt`/`lint`/`check` pass; `deno test` 29 passed.

## Note
This applies going forward — historical "Live Lobbies" days already recorded as process-only (100%) can't be reconstructed (we don't keep the per-cycle feed correlation), so the stripe will reflect true functional uptime from deploy onward.

https://claude.ai/code/session_01Q5ajSvRJDP1UUu7EHybdzL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5ajSvRJDP1UUu7EHybdzL)_