### PR TITLE
fix: metrics disappearing after load (lobby refresh targeted wrong tbody)

### DIFF
--- a/src/api/routes/getStatus.ts
+++ b/src/api/routes/getStatus.ts
@@ -541,7 +541,7 @@ export const getStatus: Handler = async () => {
     document.getElementById("wc3mapsBadge").style.display = liveness.wc3mapsChecked ? "" : "none";
     if (metrics) document.getElementById("metrics").innerHTML = metricsHTML(metrics);
 
-    morphdom(document.querySelector("tbody"), \`<tbody>\${lobbies.map(l => \`<tr id="\${l.id}">
+    morphdom(document.getElementById("lobby-body"), \`<tbody id="lobby-body">\${lobbies.map(l => \`<tr id="\${l.id}">
       <td class="col-map" title="\${l.map}">\${l.map}</td>
       <td class="col-name" title="\${l.name}">\${l.name}</td>
       <td class="col-host">\${l.host}</td>
@@ -616,7 +616,7 @@ export const getStatus: Handler = async () => {
         <td class="checkbox-cell"><label><input type="checkbox" id="tracked" oninput="update()" title="Tracked only" /><span class="checkbox-label-text">Tracked only</span></label></td>
       </tr>
     </thead>
-    <tbody>
+    <tbody id="lobby-body">
 ${
       lobbies.map((l) =>
         `      <tr id="${l.id}">


### PR DESCRIPTION
## Bug
The metrics layout (PR #30) switched to `<table>`s, which added `<tbody>` elements *before* the lobby table in the DOM. The periodic `render()` refreshes the lobby list with `morphdom(document.querySelector("tbody"), …)`, and `querySelector("tbody")` returns the **first** tbody in the document — now the metrics table's, not the lobby list's. So ~1s after load, render() overwrote the metrics with lobby rows, making the stats "disappear" while the lobby table stayed (its own tbody was never updated).

## Fix
Give the lobby `<tbody>` an id (`#lobby-body`) and target it explicitly in both the server markup and the morphdom call, instead of relying on "first tbody".

`deno fmt`/`lint`/`check` pass; `deno test` 29 passed.

https://claude.ai/code/session_01Q5ajSvRJDP1UUu7EHybdzL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5ajSvRJDP1UUu7EHybdzL)_